### PR TITLE
Fix gain search

### DIFF
--- a/Core/Utilities/Classes/@SimulationConfiguration/run.m
+++ b/Core/Utilities/Classes/@SimulationConfiguration/run.m
@@ -10,7 +10,7 @@ SimulationConfiguration.codeWrapper(@() obj.createSimulinkInterfaceFiles(), "Gen
 
 %% Start Simulations
 if NameValueArgs.use_parsim
-    the_function = @() parsim(obj.simulation_inputs, "ShowSimulationManager","on", "UseFastRestart", "on");
+    the_function = @() parsim(obj.simulation_inputs, "ShowSimulationManager","on");
 else
     the_function = @() sim(obj.simulation_inputs);
 end

--- a/UserFiles/Configurations/+ExampleMission/@DefaultConfiguration/configureParameters.m
+++ b/UserFiles/Configurations/+ExampleMission/@DefaultConfiguration/configureParameters.m
@@ -55,6 +55,7 @@ parameter_creator = ParameterCreator(InitialPlantStates, ...
 % GNC Algorithms
 gnc_delay = 1;
 InitialActuatorCommands.ReactionWheels.torque_commands__N_m = zeros(3,1);
+InitialActuatorCommands.MagneticTorquers.magnetic_dipole_moment_commands__A_m2 = zeros(3,1);
 
 parameter_creator.activateDelay("GncAlgorithms", gnc_delay, InitialActuatorCommands);
 

--- a/UserFiles/Configurations/+ExampleMission/@GainSearch/GainSearch.m
+++ b/UserFiles/Configurations/+ExampleMission/@GainSearch/GainSearch.m
@@ -2,7 +2,7 @@ classdef GainSearch < ExampleMission.DefaultConfiguration
 
     methods (Static)
         function parameters_cells = configureParameters()
-            num_Kp_values = 5;
+            num_Kp_values = 7;
             Kp_values = 10.^linspace(-5,1,num_Kp_values);
             Kd_values = Kp_values;
             [Kp_mesh, Kd_mesh] = meshgrid(Kp_values, Kd_values);
@@ -42,29 +42,29 @@ classdef GainSearch < ExampleMission.DefaultConfiguration
     end
 
     methods (Access = public)
-        function fig = plotSettlingTime(obj)
+        function fig = plotRmsError(obj)
             num_simulations = numel(obj.parameters_cells);
-            settling_times = inf(num_simulations, 1);
-            kp = nan(size(settling_times));
+            rms_error = inf(num_simulations, 1);
+            kp = nan(size(rms_error));
             kd = kp;
             for index = 1:num_simulations
                 error_quaternion = obj.simulation_outputs(index).logsout{6}.Values.error_quaternion_RB;
-                [~, angles] = smu.unitQuat.rot.toAxisAngle(error_quaternion.Data');
-                settling_times_index = find(abs(rad2deg(angles)) > 1, 1, "last");
-                settling_times(index) = error_quaternion.Time(settling_times_index);
+                [~, angles] = smu.unitQuat.rot.toAxisAngle((sign(error_quaternion.Data(:,1)) .* error_quaternion.Data)');
+                duration = error_quaternion.Time(end) - error_quaternion.Time(1);
+                rms_error(index) = sqrt(trapz(error_quaternion.Time, angles'.^2) / duration);
 
                 kp(index) = obj.parameters_cells{index}.GncAlgorithms.QuaternionFeedbackControl.Kp;
                 kd(index) = obj.parameters_cells{index}.GncAlgorithms.QuaternionFeedbackControl.Kd;
             end
             fig = figure;
-            scatter(kp, kd, [], settling_times, 'filled');
+            scatter(kp, kd, [], rms_error, 'filled');
             cb = colorbar;
             xlabel('Proportional Gain');
             ylabel('Derivative Gain');
-            ylabel(cb, 'Settling Time in s');
+            ylabel(cb, 'RMS Angle Error in rad^2 s');
             yscale('log');
             xscale('log');
-            title('Settling Time During Gain Search');
+            title('RMS Angle Error During Gain Search');
         end
     end
 end


### PR DESCRIPTION
Gain Search example would not work because `FastRestart` was enabled by default. Also, a new method for plotting the rms angle error was implemented instead of the previous one for plotting the settling time.